### PR TITLE
Diagnostics and fix/workaround on 214 error

### DIFF
--- a/timeflux_amti/nodes/driver.py
+++ b/timeflux_amti/nodes/driver.py
@@ -163,11 +163,6 @@ class ForceDriver(Node):
 
     def update(self):
         """Read samples from the AMTI force platform"""
-        # Send diagnostic dictionary as metadata when it is set
-        if self._diagnostics_dict is not None:
-            self.o.meta = self._diagnostics_dict
-            self._diagnostics_dict = None
-
         # The first time, drop all samples that might have been captured
         # between the initialization and the first time this is called.
         # This step is crucial to get a correct estimation of the drift.
@@ -234,6 +229,12 @@ class ForceDriver(Node):
 
             # Write output to timeflux
             self.o.set(data, timestamps=timestamps[:-1], names=self._channel_names)
+
+            # Send diagnostic dictionary as metadata when it is set, but wait until there is data first
+            # (otherwise hdf5.save will complain)
+            if self._diagnostics_dict is not None:
+                self.o.meta = self._diagnostics_dict
+                self._diagnostics_dict = None
 
     def terminate(self):
         """Release the DLL and internal variables."""

--- a/timeflux_amti/nodes/driver.py
+++ b/timeflux_amti/nodes/driver.py
@@ -317,6 +317,10 @@ class ForceDriver(Node):
             info = dict(index=dev)
             self.driver.fmDLLSelectDeviceIndex(dev)
 
+            # run mode
+            info['run_mode'] = self.driver.fmGetRunMode()
+            # acquisition rate
+            info['acquisition_rate'] = self.driver.fmGetAcquisitionRate()
             # product type
             info['product_type'] = self.driver.fmGetProductType()
             # amplifier model number
@@ -341,11 +345,16 @@ class ForceDriver(Node):
             self.driver.fmGetDACGainsTable(f6_buffer)
             info['DAC_gains_table'] = list(f6_buffer)
             # DAC offset table
-
+            self.driver.fmGetDACOffsetTable(f6_buffer)
+            info['DAC_offset_table'] = list(f6_buffer)
             # DAC sensitivity table
-
+            self.driver.fmGetDACSensivityTable(f6_buffer)
+            info['DAC_sensitivity_table'] = list(f6_buffer)
             # DAC sensitivities
-
+            self.driver.fmGetDACSensitivities(f6_buffer)
+            info['DAC_senstivities'] = list(f6_buffer)
+            # ADRef
+            info['AD_ref'] = self.driver.fmGetADRef()
             # gains
             self.driver.fmGetCurrentGains(l6_buffer)
             info['gains'] = list(l6_buffer)
@@ -369,13 +378,6 @@ class ForceDriver(Node):
             self._retry(lambda: self.driver.fmGetAnalogMaxAndMin(f12_buffer) != 1,
                         num_retries=3, wait=1, description='Obtaining analog max and min')
             info['analog_max_and_min'] = list(f12_buffer)
-            # sensitivity table
-
-            # run mode
-
-            # acquisition rate
-
-            # product type
 
             diagnostics_all.append(info)
 

--- a/timeflux_amti/nodes/driver.py
+++ b/timeflux_amti/nodes/driver.py
@@ -243,6 +243,11 @@ class ForceDriver(Node):
         if sys.platform != 'win32':
             raise TimefluxAmtiException('This node is supported on Windows only')
 
+        # Setup some DLL functions that do not return int but something else
+        self.driver.fmGetCableLength.restype = ctypes.c_float
+        self.driver.fmGetPlatformRotation.restype = ctypes.c_float
+        self.driver.fmGetADRef.restype = ctypes.c_float
+
         # DLL initialization as specified in SDK section 7.0
         self.logger.info('Initializing driver...')
         self.driver.fmDLLInit()

--- a/timeflux_amti/nodes/driver.py
+++ b/timeflux_amti/nodes/driver.py
@@ -312,6 +312,9 @@ class ForceDriver(Node):
         """
         self.logger.info('Releasing AMTIUSBDevice')
         self.driver.fmBroadcastStop()
+        retcode = self.driver.fmDLLSaveConfiguration()
+        if retcode != 1:
+            self.logger.warning('Could not save DLL configuration')
         self.driver.fmDLLShutDown()
         time.sleep(0.500)  # Sleep 500ms as specified in SDK section 7.0
         self.logger.info('Device released')

--- a/timeflux_amti/nodes/driver.py
+++ b/timeflux_amti/nodes/driver.py
@@ -321,16 +321,16 @@ class ForceDriver(Node):
             info['product_type'] = self.driver.fmGetProductType()
             # amplifier model number
             self.driver.fmGetAmplifierModelNumber(c32_buffer)
-            info['amplifier_model_number'] = str(c32_buffer)
+            info['amplifier_model_number'] = ctypes.cast(c32_buffer, ctypes.c_char_p).value.decode('ascii')
             # amplifier serial number
             self.driver.fmGetAmplifierSerialNumber(c32_buffer)
-            info['amplifier_serial_number'] = str(c32_buffer)
+            info['amplifier_serial_number'] = ctypes.cast(c32_buffer, ctypes.c_char_p).value.decode('ascii')
             # amplifier firmware version
             self.driver.fmGetAmplifierFirmwareVersion(c32_buffer)
-            info['amplifier_firmware_version'] = str(c32_buffer)
+            info['amplifier_firmware_version'] = ctypes.cast(c32_buffer, ctypes.c_char_p).value.decode('ascii')
             # amplifier last calibration date
             self.driver.fmGetAmplifierDate(c32_buffer)
-            info['amplifier_last_calibration_date'] = str(c32_buffer)
+            info['amplifier_last_calibration_date'] = ctypes.cast(c32_buffer, ctypes.c_char_p).value.decode('ascii')
             # gain table
             self.driver.fmGetGainTable(f24_buffer)
             info['gain_table'] = list(f24_buffer)
@@ -365,11 +365,10 @@ class ForceDriver(Node):
             self._retry(lambda: self.driver.fmGetMechanicalMaxAndMin(f12_buffer) != 1,
                         num_retries=3, wait=1, description='Obtaining mechanical max and min')
             info['mechanical_max_and_min'] = list(f12_buffer)
-            # # analog max and min
-            # if self.driver.fmGetAnalogMaxAndMin(f12_buffer) != 1:
-            #     raise RuntimeError('Unexpected return value to fmGetAnalogMaxAndMin')
-            # info['analog_max_and_min'] = list(f12_buffer)
-
+            # analog max and min
+            self._retry(lambda: self.driver.fmGetAnalogMaxAndMin(f12_buffer) != 1,
+                        num_retries=3, wait=1, description='Obtaining analog max and min')
+            info['analog_max_and_min'] = list(f12_buffer)
             # sensitivity table
 
             # run mode
@@ -380,7 +379,7 @@ class ForceDriver(Node):
 
             diagnostics_all.append(info)
 
-        self.logger.info('AMTI diagnostics results:\n %s',
+        self.logger.info('AMTI diagnostics results:\n%s',
                          json.dumps(diagnostics_all, indent=2))
 
     def _retry(self, predicate, num_retries=3, wait=1, description=None, exception=None):


### PR DESCRIPTION
For information, I am merging this branch concerning the investigation and work around when the force values are completely out of range.  It could be explained by a weird configuration status as suggested by a code 214 of the `fmDLLSetupCheck` function.

To arrive to this conclusion, I had to implement a whole diagnostic function that queries the AMTI DLL, amplifier and platform for their configuration. The code 214 was the only difference between the machine that works and the other machine that had the range problem.

In the last commits, I am adding a `fmDLLSave` to force a save configuration and thrown an error so that the next time the node is used, the setup check should fall back to the correct configuration and continue correctly, getting a code 1 instead of 214.